### PR TITLE
removed importScripts is not defined error.

### DIFF
--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -39,7 +39,9 @@ if (!Function.prototype.bind) {
   };
 }
 
-importScripts('openpgp.js');
+if( 'function' === typeof importScripts) {
+  importScripts('openpgp.js');
+}
 
 var MIN_SIZE_RANDOM_BUFFER = 40000;
 var MAX_SIZE_RANDOM_BUFFER = 60000;


### PR DESCRIPTION
fix: As this be evaluated twice from the browser we will get 
`Uncaught ReferenceError: importScripts is not defined`
Added safeguard to remove this error
